### PR TITLE
Export only the browserify transform by default, allowing for webpack…

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,25 @@
+{
+    "rules": {
+        "indent": [
+            2,
+            4
+        ],
+        "quotes": [
+            2,
+            "single"
+        ],
+        "linebreak-style": [
+            2,
+            "unix"
+        ],
+        "semi": [
+            2,
+            "always"
+        ]
+    },
+    "env": {
+        "node": true,
+        "browser": true
+    },
+    "extends": "eslint:recommended"
+}

--- a/index.js
+++ b/index.js
@@ -6,17 +6,10 @@ var glslunit = require('./lib/glsl-compiler'),
     fs = require('fs'),
     path = require('path'),
     falafel = require('falafel'),
-    path = require('path'),
     callerPath = require('caller-path');
 
-module.exports = function(a, b) {
-    var base = callerPath();
-    if (base.match(new RegExp('node_modules\\' + path.sep + 'browserify'))) {
-        return browserify(a);
-    } else {
-        return node(a, b, base);
-    }
-};
+module.exports = browserify;
+module.exports.node = node;
 
 function browserify(file) {
     var data = '',
@@ -63,7 +56,8 @@ function browserify(file) {
     return stream;
 }
 
-function node(filePath, prepend, base) {
+function node(filePath, prepend) {
+    var base = callerPath();
     var fragmentPath = path.resolve(base, '..', filePath.replace('.*.', '.fragment.')),
         fragment = fs.readFileSync(fragmentPath, 'utf8'),
         vertexPath = path.resolve(base, '..', filePath.replace('.*.', '.vertex.')),

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "browserify": "~3.38.0",
     "concat-stream": "~1.4.4",
+    "eslint": "^1.8.0",
     "tap": "~0.4.8"
   },
   "keywords": [
@@ -28,6 +29,6 @@
     "url": "git@github.com:mapbox/glify.git"
   },
   "scripts": {
-    "test": "tap test/*.js"
+    "test": "eslint index.js && tap test/*.js"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -15,6 +15,6 @@ test('browserified glify', function(t) {
 });
 
 test('nodeified glify', function(t) {
-    t.deepEqual(glify('../example/fill.*.glsl'), result);
+    t.deepEqual(glify.node('../example/fill.*.glsl'), result);
     t.end();
 });


### PR DESCRIPTION
… intercompatibility.

Downstream: https://github.com/mapbox/mapbox-gl-js/issues/1649
